### PR TITLE
Use collective subroutine and random_init

### DIFF
--- a/pi_monte_carlo_coarrays.f90
+++ b/pi_monte_carlo_coarrays.f90
@@ -3,7 +3,7 @@
 ! Vincent Magnin, 2021-04-22
 ! Last modification: 2021-05-03
 ! MIT license
-! $ caf -Wall -Wextra -std=f2008 -pedantic -O3 pi_monte_carlo_coarrays.f90 && time cafrun -n 4 ./a.out
+! $ caf -Wall -Wextra -std=f2018 -pedantic -O3 pi_monte_carlo_coarrays.f90 && time cafrun -n 4 ./a.out
 ! or with ifort :
 ! $ ifort -O3 -coarray pi_monte_carlo_coarrays.f90 && time ./a.out
 
@@ -12,14 +12,14 @@ program pi_monte_carlo_coarrays_steady
     implicit none
     real(wp)        :: x, y     ! Coordinates of a point
     integer(int64)  :: n        ! Total number of points
-    integer(int64)  :: k[*]     ! Points into the quarter disk
+    integer(int64)  :: k        ! Points into the quarter disk
     integer(int64)  :: i        ! Loop counter
-    integer(int64)  :: j, kt
     integer(int64)  :: n_per_image     ! Number of parallel images
 
     n = 1000000000
     k = 0
 
+    call random_init(repeatable=.true., image_distinct=.true.)
     print '(i2, a, i2, a)', this_image(), "/", num_images(), " images"
     n_per_image = n / num_images()
     print '(a, i11, a)', "I will compute", n_per_image, " points"
@@ -34,15 +34,10 @@ program pi_monte_carlo_coarrays_steady
     end do
 
     ! At the end:
-    sync all
+    call co_sum(k, result_image = 1)
     if (this_image() == 1) then
-        kt = 0
-        do j = 1, num_images()
-            kt = kt + k[j]
-        end do
-
         write(*,*)
-        write(*, '(a, i0, a, i0)') "4 * ", kt, " / ", n
-        write(*, '(a, f17.15)') "Pi ~ ", (4.0_wp * kt) / n
+        write(*, '(a, i0, a, i0)') "4 * ", k, " / ", n
+        write(*, '(a, f17.15)') "Pi ~ ", (4.0_wp * k) / n
     end if
 end program pi_monte_carlo_coarrays_steady

--- a/pi_monte_carlo_coarrays_steady.f90
+++ b/pi_monte_carlo_coarrays_steady.f90
@@ -3,7 +3,7 @@
 ! Vincent Magnin, 2021-04-22
 ! Last modification: 2021-05-03
 ! MIT license
-! $ caf -Wall -Wextra -std=f2008 -pedantic -O3 pi_monte_carlo_coarrays_steady.f90 && time cafrun -n 4 ./a.out
+! $ caf -Wall -Wextra -std=f2018 -pedantic -O3 pi_monte_carlo_coarrays_steady.f90 && time cafrun -n 4 ./a.out
 ! or with ifort :
 ! $ ifort -O3 -coarray pi_monte_carlo_coarrays_steady.f90 && time ./a.out
 
@@ -12,13 +12,14 @@ program pi_monte_carlo_coarrays_steady
     implicit none
     real(wp)        :: x, y     ! Coordinates of a point
     integer(int64)  :: n        ! Total number of points
-    integer(int64)  :: k[*]     ! Points into the quarter disk
+    integer(int64)  :: k        ! Points into the quarter disk
+    integer(int64)  :: it, kt   ! for intermediate sum
     integer(int64)  :: i        ! Loop counter
-    integer(int64)  :: j, kt, it
     integer(int64)  :: n_per_image     ! Number of parallel images
 
     n = 1000000000
     k = 0
+    call random_init(repeatable=.true., image_distinct=.true.)
 
     print '(i2, a, i2, a)', this_image(), "/", num_images(), " images"
     n_per_image = n / num_images()
@@ -34,14 +35,10 @@ program pi_monte_carlo_coarrays_steady
 
         ! Once in a while (20 times):
         if (mod(i, n_per_image/20) == 0) then
-            sync all
+            kt = k
+            call co_sum(kt, result_image = 1)
             if (this_image() == 1) then
-                kt = 0
-                do j = 1, num_images()
-                    kt = kt + k[j]
-                end do
                 it = i*num_images()
-
                 write(*, '(a, i0, a, i0, a, F17.15)') "4 * ", kt, " / ", it, " = ", (4.0_wp * kt) / it
             end if
         end if

--- a/pi_monte_carlo_openmp.f90
+++ b/pi_monte_carlo_openmp.f90
@@ -3,7 +3,7 @@
 ! Vincent Magnin, 2021-04-22
 ! Last modification: 2021-05-03
 ! MIT license
-! $ gfortran -Wall -Wextra -std=f2008 -pedantic -O3 -fopenmp pi_monte_carlo_openmp.f90 && time ./a.out
+! $ gfortran -Wall -Wextra -std=f2018 -pedantic -O3 -fopenmp pi_monte_carlo_openmp.f90 && time ./a.out
 
 program pi_monte_carlo_openmp
     use, intrinsic :: iso_fortran_env, only: wp=>real64, int64
@@ -14,6 +14,7 @@ program pi_monte_carlo_openmp
     integer(int64)  :: i        ! Loop counter
 
     n = 1000000000
+    call random_init(repeatable=.true., image_distinct=.true.)
 
     !$OMP PARALLEL DO DEFAULT(NONE) SCHEDULE(STATIC) &
     !$OMP SHARED(n) PRIVATE(i, x, y) REDUCTION(+: k)

--- a/pi_monte_carlo_serial.f90
+++ b/pi_monte_carlo_serial.f90
@@ -3,7 +3,7 @@
 ! Vincent Magnin, 2021-04-22
 ! Last modification: 2021-05-03
 ! MIT license
-! $ gfortran -Wall -Wextra -std=f2008 -pedantic -O3 pi_monte_carlo_serial.f90 && time ./a.out
+! $ gfortran -Wall -Wextra -std=f2018 -pedantic -O3 pi_monte_carlo_serial.f90 && time ./a.out
 ! $ ifort -O3 pi_monte_carlo_serial.f90 && time ./a.out
 
 program pi_monte_carlo_serial
@@ -15,6 +15,7 @@ program pi_monte_carlo_serial
     integer(int64)  :: i        ! Loop counter
 
     n = 1000000000
+    call random_init(repeatable=.true., image_distinct=.true.)
 
     do i = 1, n
         ! Computing a random point (x,y) into the square 0<=x<1, 0<=y<1:


### PR DESCRIPTION
This *should* improve the performance versus openmp (at least on super computers). The collective subroutines should be much better than using coarrays to do the sum across images by hand.

Also, you should be using `random_init` to be sure you're getting different sets of random numbers on different images. Also, the state of the random number generator isn't very well defined without it. I'm not sure how that plays into using openmp.