### PR TITLE
Co_sum  + openmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,24 @@ With 4 images/threads (except of course Serial):
 | Co_sum               |   4.16   |  9.29   |         |
 | Co_sum steady        |   8.18   | 10.94   |         |
 
+
+With 2 images/threads (except of course Serial) with additional co_sum and openMP benchmark on on an 13th Gen Intel(R) Core(TM) i5-13500, under Ubuntu 22.04. The gfortran `co_sum` method inclues the `-flto` flag as below. The compiler versions are:
+* gfortran 11.4.0
+* ifort 2021.11.1
+* ifx 2024.0.2
+
+
+| Version              | gfortran | ifort   | ifx     |
+| -------------------- | -------- | ------- | ------- |
+| Serial               |  11.11   | 28.02   | 14.26   |
+| OpenMP               |  7.86    | 14.40   | 5.37    |
+| Coarrays             |  8.06    | 10.42   | 7.29    |
+| Coarrays steady      |  8.98    | 16.85   | 14.38   |
+| Co_sum               |  2.12    | 10.45   | 6.99    |
+| Co_sum steady        |  3.37    | 10.93   | 10.93   |
+| Co_sum & openMP      |  1.12    | 7.59    | 2.72    |
+
+
 ### Further optimization
 
 With gfortran, the `-flto` *([standard link-time optimizer](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html))* compilation option has a strong effect on this algorithm: for example, with the `co_sum` version the CPU time with 4 images falls from 4.16 s to 2.38 s!

--- a/pi_monte_carlo_co_sum_openmp.f90
+++ b/pi_monte_carlo_co_sum_openmp.f90
@@ -1,0 +1,68 @@
+! Computes an approximation of Pi with a Monte Carlo algorithm
+! Co_sum with final results
+! Vincent Magnin, 2021-04-22
+! and Brad Richardson
+! and Ryan Bignell
+! Last modification: 2024-01-17
+! MIT license
+! $ caf -Wall -Wextra -std=f2018 -pedantic -O3 -fopenmp m_xoroshiro128plus.f90 pi_monte_carlo_co_sum_openmp.f90
+! $ cafrun -n 4 ./a.out
+! or with ifort :
+! $ ifort -O3 -qopenmp -coarray m_xoroshiro128plus.f90 pi_monte_carlo_co_sum.f90
+
+program pi_monte_carlo_co_sum_openmp
+     use, intrinsic :: iso_fortran_env, only: wp=>real64, int64
+    use m_xoroshiro128plus
+    use omp_lib, only: omp_get_thread_num
+    implicit none
+    type(rng_t)     :: rng          ! xoroshiro128+ pseudo-random number generator
+    real(wp)        :: x, y         ! Coordinates of a point
+    integer(int64)  :: n            ! Total number of points
+    integer(int64)  :: k            ! Points into the quarter disk
+    integer(int64)  :: i            ! Loop counter
+    integer(int64)  :: n_per_image  ! Number of parallel images
+    integer         :: t1, t2       ! Clock ticks
+    real            :: count_rate   ! Clock ticks per second
+    integer         :: thread       ! OpenMP thread number    
+    
+    n = 1000000000
+    k = 0
+
+    call system_clock(t1, count_rate)
+    
+    !$OMP PARALLEL DEFAULT(NONE) SHARED(n_per_image,n) PRIVATE(thread, i, x, y, rng) REDUCTION(+: k)
+    thread = omp_get_thread_num()
+    
+    ! Each image will have its own RNG seed:
+    call rng%seed([ -1337_i8, 9812374_i8 ] + 10*this_image() + 10 * thread)
+    x = rng%U01()
+
+    n_per_image = n / num_images()
+    write(*, '(a, i3, a, i3)', advance='no') "Image ", this_image(), "/", num_images()
+    write(*, '(a, i11, a)') " will compute", n_per_image, " points"
+
+    !$OMP DO SCHEDULE(STATIC) 
+    do i = 1, n_per_image
+        ! Computing a random point (x,y) into the square 0<=x<1, 0<=y<1:
+        x = rng%U01()
+        y = rng%U01()
+
+        ! Is it in the quarter disk (R=1, center=origin) ?
+        if ((x**2 + y**2) < 1.0_wp) k = k + 1
+     end do
+     !$OMP END DO
+     !$OMP END PARALLEL
+
+    ! At the end:
+    call co_sum(k, result_image = 1)
+    if (this_image() == 1) then
+        write(*,*)
+        write(*, '(a, i0, a, i0)', advance='no') "4 * ", k, " / ", n
+        write(*, '(a, f17.15)') " = ", (4.0_wp * k) / n
+
+        call system_clock(t2)
+        write(*,'(a, f6.3, a)') "Execution time: ", (t2 - t1) / count_rate, " s"
+        write(*,'(a)') "---------------------------------------------------"
+    end if
+
+  end program pi_monte_carlo_co_sum_openmp


### PR DESCRIPTION
I have added a version which uses both coarrays (specifically the co_sum form) and openMP together.

I have also updated the benchmark file such that it includes coarray results for the `ifx` compiler now that it supports coarrays (at least sufficiently for this code).

I have added the benchmark results from my PC into the readme. The ones from your benchmarking are still present.